### PR TITLE
Add to git repo history instead of `git push --forcing`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,8 +33,9 @@ remote_branch=${INPUT_REMOTE_BRANCH}
 cd $GITHUB_WORKSPACE
 
 git remote add pages-remote $remote_repo
+git fetch
 
-if ! git ls-remote --exit-code --heads pages-remote "$remote_branch" > /dev/null;
+if ! git ls-remote --exit-code --heads pages-remote "$remote_branch";
 then
   git checkout -b $remote_branch
   git push -u pages-remote $remote_branch

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,8 +32,9 @@ remote_branch=${INPUT_REMOTE_BRANCH}
 
 cd $GITHUB_WORKSPACE
 
-git checkout -b $remote_branch
-git pull $remote_repo $remote_branch
+git remote add pages-remote $remote_repo
+git checkout -b $remote_branch pages-remote/$remote_branch
+git pull pages-remote $remote_branch
 mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git
 
 git config user.name "${INPUT_GITHUB_ACTOR}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ remote_branch=${INPUT_REMOTE_BRANCH}
 cd $GITHUB_WORKSPACE
 
 git checkout -b $remote_branch
-git pull
+git pull $remote_repo $remote_branch
 mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git
 
 git config user.name "${INPUT_GITHUB_ACTOR}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,13 +37,10 @@ mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolde
 
 git config user.name "${INPUT_GITHUB_ACTOR}"
 git config user.email "${INPUT_GITHUB_ACTOR}@users.noreply.github.com"
-git add -u
+git add -A
 
 echo -n 'Files to Commit:'
 ls -l | wc -l
 
 git commit -m 'mawl build.' > /dev/null 2>&1
-git push --set-upstream origin $remote_branch
-# echo "Removing git..."
-rm -fr .git
-echo 'Done'
+git push --set-upstream $remote_repo $remote_branch

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,7 @@ remote_branch=${INPUT_REMOTE_BRANCH}
 cd $GITHUB_WORKSPACE
 
 git checkout -b $remote_branch
+git pull
 mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git
 
 git config user.name "${INPUT_GITHUB_ACTOR}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,40 +1,48 @@
 #!/bin/bash
 
 set -xeo pipefail
-cd /arquivo
-echo "\n\n\n#########\nimporting\n-------------"
+
+# where is our markdown stored?
 if [ ! -z ${INPUT_INPUT_FOLDER} ]; then
   input_path="${GITHUB_WORKSPACE}/${INPUT_INPUT_FOLDER}"
 else
   input_path=$GITHUB_WORKSPACE
 fi
 
-STATIC_PLS=true NOTEBOOK_PATH=$input_path bundle exec rails static:import
+# where are we pushing the generated html to?
+# TODO: this can probably be replaced with checkout@v3,
+# which persists a PAT in the git config?
+remote_repo="https://${INPUT_GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${INPUT_GITHUB_REPOSITORY}.git" && \
+remote_branch=${INPUT_REMOTE_BRANCH}
+
+
+echo -n "\n\n\n#########\nimporting\n-------------"
+
+cd /arquivo
+STATIC_PLS=true NOTEBOOK_PATH="$input_path" bundle exec rails static:import
 
 # we boot up the server in the bg
 STATIC_PLS=true bundle exec rails s -d
 
-echo "\n\n\n#########\nbuilding\n-------------"
+echo -n "\n\n\n#########\nbuilding\n-------------"
 
-# so we can fetch the static html
 STATIC_PLS=true bundle exec rails static:generate
-cd /arquivo/out
-
-echo "\n\n\n#########\npublishing\n-------------"
 
 if [ ! -z ${INPUT_CNAME} ]; then
-  echo ${INPUT_CNAME} > CNAME
+  echo ${INPUT_CNAME} > /arquivo/out/CNAME
 fi
 
-
-remote_repo="https://${INPUT_GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${INPUT_GITHUB_REPOSITORY}.git" && \
-remote_branch=${INPUT_REMOTE_BRANCH}
+# our html has been generated! let's push this out.
+echo -n "\n\n\n#########\npublishing\n-------------"
 
 cd $GITHUB_WORKSPACE
 
+# TODO: again, probably not necessary to add a remote?
 git remote add pages-remote $remote_repo
 git fetch pages-remote
 
+# if the remote branch does not exist, create it
+# else, check it out & fetch latest contents
 if ! git ls-remote --exit-code --heads pages-remote "$remote_branch";
 then
   git checkout -b $remote_branch
@@ -44,13 +52,15 @@ else
   git pull pages-remote $remote_branch
 fi
 
+# sometimes files might be deleted. preserving the .git folder,
+# we just delete everything & copy over the generated html
 mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git
 
 git config user.name "${INPUT_GITHUB_ACTOR}"
 git config user.email "${INPUT_GITHUB_ACTOR}@users.noreply.github.com"
 git add -A
 
-echo -n 'Files to Commit:'
+echo -n 'Files to Commit: '
 ls -l | wc -l
 
 git commit -m 'mawl build.' > /dev/null 2>&1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ remote_branch=${INPUT_REMOTE_BRANCH}
 
 cd $GITHUB_WORKSPACE
 
-git switch $remote_branch
+git checkout -b $remote_branch
 mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git
 
 git config user.name "${INPUT_GITHUB_ACTOR}"
@@ -43,7 +43,7 @@ echo -n 'Files to Commit:'
 ls -l | wc -l
 
 git commit -m 'mawl build.' > /dev/null 2>&1
-git push
+git push --set-upstream origin $remote_branch
 # echo "Removing git..."
 rm -fr .git
 echo 'Done'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ remote_branch=${INPUT_REMOTE_BRANCH}
 cd $GITHUB_WORKSPACE
 
 git remote add pages-remote $remote_repo
-git fetch
+git fetch pages-remote
 
 if ! git ls-remote --exit-code --heads pages-remote "$remote_branch";
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,8 +33,16 @@ remote_branch=${INPUT_REMOTE_BRANCH}
 cd $GITHUB_WORKSPACE
 
 git remote add pages-remote $remote_repo
-git checkout -b $remote_branch pages-remote/$remote_branch
-git pull pages-remote $remote_branch
+
+if ! git ls-remote --exit-code --heads pages-remote "$remote_branch" > /dev/null;
+then
+  git checkout -b $remote_branch pages-remote/$remote_branch
+  git pull pages-remote $remote_branch
+else
+  git checkout -b $remote_branch
+  git push -u pages-remote $remote_branch
+fi
+
 mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git
 
 git config user.name "${INPUT_GITHUB_ACTOR}"
@@ -45,4 +53,4 @@ echo -n 'Files to Commit:'
 ls -l | wc -l
 
 git commit -m 'mawl build.' > /dev/null 2>&1
-git push --set-upstream $remote_repo $remote_branch
+git push

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,11 +36,11 @@ git remote add pages-remote $remote_repo
 
 if ! git ls-remote --exit-code --heads pages-remote "$remote_branch" > /dev/null;
 then
-  git checkout -b $remote_branch pages-remote/$remote_branch
-  git pull pages-remote $remote_branch
-else
   git checkout -b $remote_branch
   git push -u pages-remote $remote_branch
+else
+  git checkout -b $remote_branch pages-remote/$remote_branch
+  git pull pages-remote $remote_branch
 fi
 
 mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,19 +26,24 @@ if [ ! -z ${INPUT_CNAME} ]; then
   echo ${INPUT_CNAME} > CNAME
 fi
 
+
 remote_repo="https://${INPUT_GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${INPUT_GITHUB_REPOSITORY}.git" && \
 remote_branch=${INPUT_REMOTE_BRANCH}
 
-git init
+cd $GITHUB_WORKSPACE
+
+git switch $remote_branch
+mv .git /tmp/gitfolder && rm -rf * && cp -r /arquivo/out/. . && mv /tmp/gitfolder .git
+
 git config user.name "${INPUT_GITHUB_ACTOR}"
 git config user.email "${INPUT_GITHUB_ACTOR}@users.noreply.github.com"
-git add .
+git add -u
 
 echo -n 'Files to Commit:'
 ls -l | wc -l
 
 git commit -m 'mawl build.' > /dev/null 2>&1
-git push --force $remote_repo master:$remote_branch > /dev/null 2>&1
+git push
 # echo "Removing git..."
 rm -fr .git
 echo 'Done'


### PR DESCRIPTION
The original version of this action was always doing a `git push --force` which _worked_ but had two downsides:

- detached the prev history from the repo network, causing the repo disk size to balloon under the hood & eventually requiring a GC step in the github side (awkward to have hundred meg repos for a simple website, cos of all of the orphaned history)
- made it impossible to track bugs in the renderer or rollback to previous changes

After a LOT of trial and error I figured out how to incrementally add to the history of the `gh-pages` branch. Success!